### PR TITLE
implements webpack build process for node server code

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:client && npm run build:server && npm run build:node",
     "build:client": "cross-env NODE_ENV=production webpack -p --config webpack/client.production.js",
     "build:server": "cross-env NODE_ENV=production webpack -p --config webpack/server.production.js",
-    "build:node": "babel src/index.js -o public/index.js"
+    "build:node": "cross-env NODE_ENV=production webpack -p --config webpack/node.production.js"
   },
   "keywords": [
     "ssr",

--- a/scripts/extended-node-externals.js
+++ b/scripts/extended-node-externals.js
@@ -1,0 +1,10 @@
+const nodeExternals = require('./node-externals');
+const projectExternals = {
+    './assets/stats.json': 'commonjs ./assets/stats.json',
+    './assets/app.server.js': 'commonjs ./assets/app.server.js'
+};
+
+module.exports = {
+    ...nodeExternals,
+    ...projectExternals
+};

--- a/webpack/node.production.js
+++ b/webpack/node.production.js
@@ -1,0 +1,29 @@
+const merge = require('webpack-merge');
+const webpack = require('webpack');
+const common = require('./common');
+const join = require('path').join;
+const extendedNodeExternals = require('../scripts/extended-node-externals');
+
+module.exports = merge(common, {
+    target: 'node',
+    externals: extendedNodeExternals,
+    node: {
+        __dirname: false,
+        __filename: false
+    },
+    entry: [
+        'babel-polyfill',
+        join(__dirname, '../src/index')
+    ],
+    output: {
+        filename: 'index.js',
+        path: join(__dirname, '../public'),
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env': {
+                'NODE_ENV': JSON.stringify('production')
+            }
+        })
+    ]
+});


### PR DESCRIPTION
Formerly, the build process for `src/index` which contains the express server code was only a one-to-one transpilation of the file via babel.
This caused problems, when you required/imported other files inside the `src\index` since no bundling was involved.

I created a webpack build to make use of bundling and fix #9 